### PR TITLE
Adding waiting in queue to non-ready reservation statuses

### DIFF
--- a/src/Solvberget.Nancy/Mapping/DtoMaps.cs
+++ b/src/Solvberget.Nancy/Mapping/DtoMaps.cs
@@ -14,6 +14,8 @@ namespace Solvberget.Nancy.Mapping
 {
     public static class DtoMaps
     {
+        private static readonly string[] UnavailableStatuses = {"In processz38-status", "Waiting in queue"};
+
         public static LibrarylistDto Map(LibraryList list, IRepository documents = null)
         {
             if (null != documents)
@@ -49,7 +51,7 @@ namespace Solvberget.Nancy.Mapping
             {
                 Document = Map(documents.GetDocument(reservation.DocumentNumber, true)),
                 Reserved = holdFrom,
-                ReadyForPickup = reservation.Status != "In processz38-status", // business logic should not be here! :(
+                ReadyForPickup = !UnavailableStatuses.Contains(reservation.Status), // business logic should not be here! :(
                 PickupLocation = reservation.PickupLocation,
                 PickupDeadline = holdTo
             };


### PR DESCRIPTION
This approach should work well for all statuses I have observed so far. However, it is vulnerable to new non-available states.

Also worth noting: The Metro app uses the following logic:

``` C#
return holdRequestEnd == undefined || holdRequestEnd == "" 
    ? "Klar til henting: Nei" 
    : "Klar til henting: Ja";
```

If you think I should switch to using the same logic in the Nancy service I will.
